### PR TITLE
Introduce the testsuite --dev/-d option

### DIFF
--- a/src/e3/testsuite/__init__.py
+++ b/src/e3/testsuite/__init__.py
@@ -166,6 +166,14 @@ class TestsuiteCore(object):
         )
         parser.add_argument("-t", "--temp-dir", metavar="DIR", default=Env().tmp_dir)
         parser.add_argument(
+            "-d", "--dev-temp",
+            nargs="?", default=None, const="tmp",
+            help="Unlike --temp-dir, use this very directory to store"
+                 " testsuite temporaries (i.e. no random subdirectory). Also"
+                 " automatically disable temp dir cleanup, to be developer"
+                 " friendly. If no directory is provided, use the local"
+                 " \"tmp\" directory")
+        parser.add_argument(
             "--max-consecutive-failures",
             default=0,
             help="If there are more than N consecutive failures, the testsuite"
@@ -248,13 +256,25 @@ class TestsuiteCore(object):
         self.output_dir = os.path.join(d, "new")
         self.old_output_dir = os.path.join(d, "old")
 
-        if not os.path.isdir(self.main.args.temp_dir):
-            logging.critical("temp dir '%s' does not exist", self.main.args.temp_dir)
-            return 1
+        if self.main.args.dev_temp:
+            # Use a temporary directory for developers: make sure it is an
+            # empty directory and disable cleanup to ease post-mortem
+            # investigation.
+            self.working_dir = os.path.abspath(self.main.args.dev_temp)
+            rm(self.working_dir, recursive=True)
+            mkdir(self.working_dir)
+            self.main.args.enable_cleanup = False
 
-        self.working_dir = tempfile.mkdtemp(
-            "", "tmp", os.path.abspath(self.main.args.temp_dir)
-        )
+        else:
+            # If the temp dir is supposed to be randomized, we need to create a
+            # subdirectory, so check that the parent directory exists first.
+            if not os.path.isdir(self.main.args.temp_dir):
+                logging.critical("temp dir '%s' does not exist",
+                                 self.main.args.temp_dir)
+                return 1
+
+            self.working_dir = tempfile.mkdtemp(
+                "", "tmp", os.path.abspath(self.main.args.temp_dir))
 
         # Create the new output directory that will hold the results
         self.setup_result_dir()


### PR DESCRIPTION
Currently, controlling the testsuite temporary directory happens with
two flags: --temp-dir XXX (to select where to put the temporary
directory) and --disable-cleanup (to leave temporaries untouched after
the testsuite completes).

These are inconvenient for devs for two reasons. First, when you pass
--temp-dir=foo, the testuite will actually create a random foo/tmpXXX
subdirectory, making it awkward to work with test temporaries across
multiple testsuite runs. Second, one generally selects a specific
temporary directory only to inspect its content, so in practice, both
options are always used together.
    
Given that this command line interface is almost set in stone (interface
common to other testsuites), this commit adds a new switch: --dev/-d
to set the actual temporary directory (no random subdir), to
disable automatic temporaries cleanup and to enable the display of
failing test outputs.