### PR TITLE
Make AdaCoreLegacyTestControlCreator also check for shell scripts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 25.0 (Not released yet)
 =======================
 
+* `AdaCoreLegacyTestControlCreator`: also check for shell scripts (`test.sh`).
 * Always enable "cross" support for testsuites.
 * Make the default testsuite failure exit code customizable.
 

--- a/src/e3/testsuite/control.py
+++ b/src/e3/testsuite/control.py
@@ -170,12 +170,12 @@ class AdaCoreLegacyTestControlCreator(TestControlCreator):
             configuration.
         """
         # Use "test.cmd" by default. If it does not exist while there is a
-        # "test.py" file, use that instead.
-        if (
-            not os.path.isfile(driver.test_dir("test.cmd"))
-            and os.path.isfile(driver.test_dir("test.py"))
-        ):
-            return "test.py"
+        # "test.py" or a "test.sh" file, use that instead.
+        if not os.path.isfile(driver.test_dir("test.cmd")):
+            if os.path.isfile(driver.test_dir("test.py")):
+                return "test.py"
+            elif os.path.isfile(driver.test_dir("test.sh")):
+                return "test.sh"
         return "test.cmd"
 
     def default_opt_results(self,

--- a/tests/tests/adacore-tests/0000-097/test.out
+++ b/tests/tests/adacore-tests/0000-097/test.out
@@ -1,0 +1,1 @@
+success

--- a/tests/tests/adacore-tests/0000-097/test.sh
+++ b/tests/tests/adacore-tests/0000-097/test.sh
@@ -1,0 +1,2 @@
+# An empty test checking that test.sh are correctly found and considered tests
+echo success

--- a/tests/tests/test_adacore.py
+++ b/tests/tests/test_adacore.py
@@ -28,6 +28,8 @@ def test_adacore():
 
     suite = run_testsuite(Mysuite1, ["-E"])
     assert extract_results(suite) == {
+        # Check that test.sh are picked up
+        "0000-097": Status.PASS,
         # Regular test execution, exercize output refiners
         "T415-993": Status.PASS,
         # Missing non-default baseline


### PR DESCRIPTION
AdaCore legacy testsuites contain both test.cmd and test.sh files,
falling back to test.sh if test.cmd does not exist.

TN: TB25-014