### PR TITLE
ClassicTestDriver: use XFAIL message for XPASS result

### DIFF
--- a/src/e3/testsuite/driver/classic.py
+++ b/src/e3/testsuite/driver/classic.py
@@ -253,7 +253,7 @@ class ClassicTestDriver(TestDriver):
         assert not self.test_control.skip
 
         if self.test_control.xfail:
-            self.result.set_status(TestStatus.XPASS)
+            self.result.set_status(TestStatus.XPASS, self.test_control.message)
         else:
             self.result.set_status(TestStatus.PASS)
         self.push_result()

--- a/tests/tests/classic-tests/xpassed/test.yaml
+++ b/tests/tests/classic-tests/xpassed/test.yaml
@@ -2,4 +2,4 @@ driver: script-driver
 process:
     args: []
 control:
-    - [XFAIL, "True"]
+    - [XFAIL, "True", "XFAIL message"]

--- a/tests/tests/test_classic.py
+++ b/tests/tests/test_classic.py
@@ -198,6 +198,9 @@ def test_classic(caplog):
     )
     assert log in testsuite_logs(caplog)
 
+    # Check that XPASS result prints the XFAIL message
+    assert suite.report_index.entries["xpassed"].msg == "XFAIL message"
+
 
 def test_long_logs(caplog):
     """Check that long logs are truncated as requested."""


### PR DESCRIPTION
This matches the behavior of GNATpython for UOK result.

TN TC02-007.