### PR TITLE
Introduce the --cleanup-mode command line option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 25.0 (Not released yet)
 =======================
 
+* Introduce the `--cleanup-mode` command line option.
 * Make `--gaia-output` (report formatted for GAIA) faster.
 * Fix the `--max-consecutive-failures` command line option.
 * Introduce multi-processing for test fragment execution.

--- a/src/e3/testsuite/driver/__init__.py
+++ b/src/e3/testsuite/driver/__init__.py
@@ -15,6 +15,7 @@ from e3.testsuite.report.gaia import (
     dump_result_logs_if_needed,
 )
 from e3.testsuite.result import TestResult, TestResultSummary
+from e3.testsuite.utils import CleanupMode
 
 if TYPE_CHECKING:
     from e3.testsuite.fragment import FragmentCallback
@@ -198,7 +199,7 @@ class TestDriver(object, metaclass=abc.ABCMeta):
         whole testsuite are removed incrementally. This is necessary to avoid
         creating huge temporary directories when executing big testsuites.
         """
-        return self.testsuite_options.enable_cleanup
+        return self.env.cleanup_mode != CleanupMode.NONE
 
 
 class BasicTestDriver(TestDriver, metaclass=abc.ABCMeta):

--- a/src/e3/testsuite/utils.py
+++ b/src/e3/testsuite/utils.py
@@ -1,7 +1,10 @@
 """Miscellaneous helpers."""
 
+from __future__ import annotations
+
+from enum import Enum, auto
 import sys
-from typing import AnyStr, IO, Optional
+from typing import AnyStr, Dict, IO, Optional, Type, TypeVar
 
 
 def isatty(stream: IO[AnyStr]) -> bool:
@@ -46,3 +49,40 @@ class ColorConfig:
         if not colors_enabled:
             self.Fore = DummyColors()
             self.Style = DummyColors()
+
+
+class CleanupMode(Enum):
+    """Mode for working space cleanups."""
+
+    NONE = auto()
+    PASSING = auto()
+    ALL = auto()
+
+    @classmethod
+    def default(cls) -> CleanupMode:
+        return cls.PASSING
+
+    @classmethod
+    def descriptions(cls) -> Dict[CleanupMode, str]:
+        return {
+            cls.NONE: "Remove nothing.",
+            cls.PASSING: "Remove only working spaces for passing tests"
+            " (useful for post-mortem investigation with reasonable disk"
+            " usage). This is the default.",
+            cls.ALL: "Remove all working spaces.",
+        }
+
+
+EnumType = TypeVar("EnumType", bound=Enum)
+
+
+def enum_to_cmdline_args_map(enum_cls: Type[EnumType]) -> Dict[str, EnumType]:
+    """Turn enum alternatives into command-line arguments.
+
+    This helps exposing enums for options on the command-line. This turns
+    alternative names into lower case and replaces underscores with dashes.
+    """
+    return {
+        value.name.lower().replace("_", "-"): value
+        for value in enum_cls
+    }


### PR DESCRIPTION
This commit introduces the --cleanup-mode command line option and
deprecates the --disable-cleanup one. The former introduces one more
possibility: cleanup all working spaces but the ones of FAIL/ERROR
testcases (which becomes the default).