### PR TITLE
Add new script called e3-opt-parser (wrapper around the OptFileParse …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
             "e3-testsuite-report = e3.testsuite.report.display:main",
             "e3-find-skipped-tests = e3.testsuite.find_skipped_tests:main",
             "e3-run-test-fragment = e3.testsuite.fragment:run_fragment",
+            "e3-opt-parser = e3.testsuite.optfileparser:main",
         ]
     },
 )

--- a/src/e3/testsuite/optfileparser.py
+++ b/src/e3/testsuite/optfileparser.py
@@ -7,6 +7,7 @@ context.
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os.path
 import re
@@ -285,3 +286,35 @@ class OptFileParse:
 
         result = result.rstrip()
         return result
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate test.opt against set of tags"
+    )
+    parser.add_argument(
+        "opt_filename", help='The name of the "opt" file to read and evaluate'
+    )
+    parser.add_argument(
+        "tags_list",
+        metavar="TAG",
+        nargs="*",
+        help="A tag. For ease of use, this program also supports"
+        " the use of a comma-separated list of tags.",
+    )
+    args = parser.parse_args(argv)
+
+    # Build the system_tags list from the list of tags passed on
+    # the command line. The tags which include a comma are considered
+    # to be a comma-separated lists of tags, so split those into
+    # sub-list of system tags.
+    system_tags = []
+    for tag in args.tags_list:
+        system_tags.extend(tag.split(","))
+
+    opt_result = OptFileParse(system_tags, args.opt_filename)
+    print(str(opt_result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tests/test_optfileparser.py
+++ b/tests/tests/test_optfileparser.py
@@ -2,6 +2,7 @@
 
 import os.path
 
+from e3.os.process import Run
 from e3.testsuite.optfileparser import BadFormattingError, OptFileParse
 
 
@@ -147,3 +148,45 @@ def test_required():
 
     of = parse_file("required.opt", "linux,ada,c")
     assert not of.is_dead
+
+
+def run_opt_parser_script(filename, tags=None):
+    """Call e3-opt-parser and returning the corresponding e3.os.process.Run object."""
+    parser_cmd = [
+        "e3-opt-parser",
+        os.path.join(os.path.dirname(__file__), "optfiles", filename),
+    ]
+    if tags is not None:
+        parser_cmd.extend(tags)
+    return Run(parser_cmd)
+
+
+def test_main():
+    """Test the function called by the command-line wrapper to OptFileParse."""
+    p = run_opt_parser_script("tags.opt", None)
+    assert p.status == 0
+    assert (
+        p.out
+        == """\
+cmd="default.cmd"
+xfail=""
+"""
+    )
+
+    p = run_opt_parser_script("tags.opt", ["linux"])
+    assert p.status == 0
+    assert (
+        p.out
+        == """\
+cmd="linux.cmd"
+"""
+    )
+
+    p = run_opt_parser_script("tags.opt", ["linux", "powerpc"])
+    assert p.status == 0
+    assert (
+        p.out
+        == """\
+cmd="linux.cmd"
+"""
+    )


### PR DESCRIPTION
…class)

This new script allows users to determine the output of evaluating
any .opt file with a given set of tags, which helps verifying that
the commands in the .opt files are behaving as expected.

TN: UC07-024