### PR TITLE
Various flake8 fixes for Python 3.9

### DIFF
--- a/src/e3/testsuite/report/index.py
+++ b/src/e3/testsuite/report/index.py
@@ -114,7 +114,7 @@ class ReportIndex:
                     e["test_name"],
                     TestStatus[e["status"]],
                     e["msg"],
-                    set(FailureReason[fr] for fr in e["failure_reasons"]),
+                    {FailureReason[fr] for fr in e["failure_reasons"]},
                     e["time"],
                     e["info"],
                 ),

--- a/tests/tests/test_multiprocessing.py
+++ b/tests/tests/test_multiprocessing.py
@@ -27,7 +27,7 @@ class TestEnable:
             )
             self.push_result()
 
-    def run_testsuite(self, enable_expected, args=[], supported=None):
+    def run_testsuite(self, enable_expected, args=None, supported=None):
         """Run a testsuite with a single test with MyDriver."""
         MySuite = create_testsuite(["single_test"], TestEnable.MyDriver)
         if supported is not None:

--- a/tests/tests/test_running_status.py
+++ b/tests/tests/test_running_status.py
@@ -106,7 +106,7 @@ class TestBasic:
                     result.set_status(status)
                     break
             else:
-                assert False
+                raise AssertionError(f"invalid fragment name: {name}")
             self.push_result(result)
 
     def test(self):


### PR DESCRIPTION
Earlier today, I tried adding type annotations to a testsuite based on e3-testsuite. I am using Python 3.9.

I got the following errors...

../e3-testsuite/src/e3/testsuite/result.py:140: error: Redundant cast to "str"
../e3-testsuite/src/e3/testsuite/result.py:142: error: Redundant cast to "bytes"

This got me down a bit of a rabbit hole as, after installing the pre-commit hooks with my Python 3.9 interpreter, I saw that I was getting some errors even before I started making changes.

> src/e3/testsuite/report/index.py:117:21: C401 Unnecessary generator - rewrite as a set comprehension.
> tests/tests/test_running_status.py:109:17: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
> tests/tests/test_multiprocessing.py:30:51: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.

Looking deeper, I think what's happening is that this repository is currently requiring developers to use Python 3.8 (config in mypy.ini and tox.ini).

Nevertheless, I thought the errors were worth fixing, so this series of commits does so. Unfortunately, that's all the time I have right now so my own attempts at trying to use mypy on code that imports e3-testsuite will have to wait.