### PR TITLE
Handle deletion of non-existent baselines

### DIFF
--- a/src/e3/testsuite/report/rewriting.py
+++ b/src/e3/testsuite/report/rewriting.py
@@ -231,8 +231,8 @@ class BaseBaselineRewriter(abc.ABC):
                 self.print_info(
                     f"baseline file found for {test_name}, deleting it"
                 )
-            summary.deleted_baselines.add(test_name)
-            os.unlink(filename)
+                summary.deleted_baselines.add(test_name)
+                os.unlink(filename)
 
     def print_stderr(self, message: str, prefix: str, style: str = "") -> None:
         print(

--- a/tests/tests/test_baseline_rewriting.py
+++ b/tests/tests/test_baseline_rewriting.py
@@ -196,6 +196,21 @@ def test_report(tmp_path):
     check_baselines(tmp_path, updated_baselines)
 
 
+def test_deleted_baseline(tmp_path):
+    """Test baseline deletion when the baseline is already missing."""
+    br, report = do_setup(tmp_path, initial_baselines, test_results)
+    # Remove the baseline
+    os.remove(os.path.join(tmp_path, "baselines", "t-out-empty.out"))
+    deleted_expected_summary = RewritingSummary(
+        set(expected_summary.errors),
+        set(expected_summary.updated_baselines),
+        set(expected_summary.new_baselines),
+        set(),
+    )
+    assert br.rewrite(report.results_dir) == deleted_expected_summary
+    check_baselines(tmp_path, updated_baselines)
+
+
 def test_gaia(tmp_path):
     """Test baseline updates from a GAIA report."""
     br, report = do_setup(tmp_path, initial_baselines, test_results)


### PR DESCRIPTION
The previous code could crash when trying to delete a baseline that had already been removed locally.