### PR TITLE
use cpu_count if 0 jobs are specified to be run

### DIFF
--- a/src/e3/testsuite/__init__.py
+++ b/src/e3/testsuite/__init__.py
@@ -1062,9 +1062,14 @@ class TestsuiteCore:
             return False
 
         # Create a scheduler to run all fragments for the testsuite main loop
+
+        jobs = self.main.args.jobs
+        if self.main.args.jobs <= 0:
+            jobs = os.cpu_count() or 1
+
         scheduler = Scheduler(
             job_provider=job_factory,
-            tokens=self.main.args.jobs,
+            tokens=jobs,
             collect=collect_result,
         )
 

--- a/src/e3/testsuite/__init__.py
+++ b/src/e3/testsuite/__init__.py
@@ -73,7 +73,7 @@ class TestAbort(Exception):
 class TestsuiteCore:
     """Testsuite Core driver.
 
-    This class is the base of Testsuite class and should not be instanciated.
+    This class is the base of Testsuite class and should not be instantiated.
     It's not recommended to override any of the functions declared in it.
 
     See documentation of Testsuite class for overridable methods and


### PR DESCRIPTION
If consuming code's testsuite is run with `-j0`, e3-testsuite will stall indefinitely as no jobs are able to complete. This PR brings the behavior in line with make/gprbuild/etc and just uses as many CPUs as are available. Do tell me if there's anything that needs fixing; thanks so much!